### PR TITLE
Fix Attempt to write logs with no transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/Hornwitser/server_select#readme",
   "peerDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.4"
+    "@clusterio/lib": "^2.0.0-alpha.0"
   },
   "devDependencies": {
     "@clusterio/web_ui": "^2.0.0-alpha.5",


### PR DESCRIPTION
https://github.com/clusterio/clusterio/issues/429

Using the caret operator on the peerDependency version means it should now pick the latest installed version of 2.x.x-alpha.x
