### PR TITLE
Changed GUI to single column with scrollbar and search field

### DIFF
--- a/module/select.lua
+++ b/module/select.lua
@@ -25,6 +25,8 @@ end
 -- Perform fuzzy text comparison
 local function search_matches(instance_name, search_term)
     if search_term == "" then return true end
+    search_term = search_term:lower()
+    instance_name = instance_name:lower()
     local search_index = 1
     for i = 1, #instance_name do
         if instance_name:sub(i, i) == search_term:sub(search_index, search_index) then
@@ -141,11 +143,8 @@ local function server_select_gui(player)
         button.style.horizontally_stretchable = true
     end
 
-    -- Move focus to the current server if not currently searching anything
-    if not global.server_select.search_terms[player.index] then
-        scroll.scroll_to_element(scroll["server_select-instance-" .. this_instance.id], "top-third")
-    else
-        -- Move focus to search field
+    -- Move focus to search field if the user is searching for something
+    if global.server_select.search_terms[player.index] then
         search_field.focus()
     end
 end
@@ -166,12 +165,6 @@ local function on_gui_text_changed(event)
                         child.visible = search_matches(child.caption, event.element.text)
                     end
                 end
-            end
-        end
-        -- Move focus to the current server if the search field is empty
-        if event.element.text == "" then
-            if gui then
-                gui["server_select-scroll"].scroll_to_element(scroll["server_select-instance-" .. get_this_instance().id], "top-third")
             end
         end
     end


### PR DESCRIPTION
Resolves https://github.com/clusterio/clusterio/issues/597

The current server select shows a big blob of server buttons in fixed height columns. Its not particularly easy to find anything, and with a sufficient amount of servers it becomes difficult to access all of them on low resolution screens.

![image](https://github.com/Hornwitser/server_select/assets/6792749/c1cff722-fe32-4792-a1c7-207e16e774de)

Tho solve this issue, I redesigned the ingame GUI to a single column layout with a scrollbar and search field.

<img width="217" alt="image" src="https://github.com/Hornwitser/server_select/assets/6792749/cdca6918-db52-43f5-8aaf-bcf958a92b54">

The searchfield is automatically focused when opening the dialog and responds on keypress.

<img width="217" alt="image" src="https://github.com/Hornwitser/server_select/assets/6792749/3c3453b3-54f7-430a-a7c2-ef919a914ef7">

The search uses a fuzzy search where it includes results that has all of the input characters in the same order as entered in the search box. This means searching `in green 2` would match `instance 47 green circuit 2` and `Lobby instance green team 32` but not `green circuit instance 2`.