### PR TITLE
Fix TypeError: instances not iterable with clusterio alpha.23

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -11,7 +11,8 @@ class ControllerPlugin extends BaseControllerPlugin {
 	async init() {
 		this.instances = new Map();
 		if (this.controller.config.get("server_select.show_unknown_instances")) {
-			for (let [instanceId, instance] of this.controller.instances) {
+			for (let instance of this.controller.instances.values()) {
+				let instanceId = instance.id;
 				if (instance.status === "unknown") {
 					this.instances.set(instanceId, {
 						"id": instanceId,
@@ -114,7 +115,8 @@ class ControllerPlugin extends BaseControllerPlugin {
 	}
 
 	async updateInstances() {
-		for (let [instanceId, instance] of this.controller.instances) {
+		for (let instance of this.controller.instances.values()) {
+			let instanceId = instance.id;
 			if (this.shouldShowInstance(instance)) {
 				if (!this.instances.has(instanceId)) {
 					await this.updateInstanceData(instance);


### PR DESCRIPTION
## Summary

- `controller.instances` was refactored in clusterio alpha.23 from a directly iterable `SubscribableDatastore` into an `InstanceManager` wrapper class that exposes `.values()` but has no `[Symbol.iterator]`
- The two `for...of` loops in `init()` and `updateInstances()` that destructured `[instanceId, instance]` directly from `this.controller.instances` now fail with `TypeError: this.controller.instances is not iterable`
- Fixed by iterating `this.controller.instances.values()` and deriving `instanceId` from `instance.id`

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Changelog
```
### Changes
- Fixed `TypeError: this.controller.instances is not iterable` when used on Clusterio alpha 23. #5
```