### PR TITLE
Fix: online instances appearing offline due to stale status after async await

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -47,11 +47,19 @@ class ControllerPlugin extends BaseControllerPlugin {
 	}
 
 	async updateInstanceData(instance) {
-		let instanceId = instance.config.get("instance.id");
-		if (instance.status === "running") {
-			let hostConnection = this.controller.wsServer.hostConnections.get(
-				instance.config.get("instance.assigned_host")
-			);
+		// Snapshot mutable fields before any await. In alpha.23 the InstanceRecord
+		// is mutated in-place by HostConnection when new status events arrive, so
+		// reading instance.status / instance.gamePort after an await may return a
+		// newer (stale-from-our-perspective) value and cause running instances to
+		// appear offline in the in-game server list.
+		const instanceId = instance.config.get("instance.id");
+		const status = instance.status;
+		const gamePort = instance.gamePort;
+		const name = instance.config.get("instance.name");
+		const assignedHost = instance.config.get("instance.assigned_host");
+
+		if (status === "running") {
+			let hostConnection = this.controller.wsServer.hostConnections.get(assignedHost);
 			if (!hostConnection) { // Should be impossible
 				return;
 			}
@@ -61,11 +69,11 @@ class ControllerPlugin extends BaseControllerPlugin {
 			let instanceData = await this.controller.sendTo({ instanceId }, new GetInstanceRequest());
 
 			let currentData = {
-				id: instance.id,
-				name: instance.config.get("instance.name"),
-				status: instance.status,
-				game_port: instance.gamePort,
-				public_address: this.controller.hosts.get(instance.config.get("instance.assigned_host"))?.publicAddress,
+				id: instanceId,
+				name,
+				status,
+				game_port: gamePort,
+				public_address: this.controller.hosts.get(assignedHost)?.publicAddress,
 				game_version: instanceData.game_version,
 			};
 			this.instances.set(instanceId, currentData);
@@ -75,11 +83,11 @@ class ControllerPlugin extends BaseControllerPlugin {
 		if (!instanceData) {
 			instanceData = {
 				"id": instanceId,
-				"name": instance.config.get("instance.name"),
+				"name": name,
 			};
 			this.instances.set(instanceId, instanceData);
 		}
-		instanceData["status"] = instance.status;
+		instanceData["status"] = status;
 		return instanceData;
 	}
 


### PR DESCRIPTION
## Summary

This PR proposes a fix for a race condition in `updateInstanceData` that can cause running instances to appear offline in the in-game server select GUI.

> **Note:** This fix was identified and written with the assistance of an AI (Claude). While the root cause analysis and proposed fix appear sound, the code **may be inaccurate or incomplete**. Please review carefully before merging.

---

## Root Cause

In clusterio alpha.23, `InstanceRecord` objects are **mutated in-place** by `HostConnection.handleInstanceStatusChangedEvent` when new status events arrive from the host:

```js
// HostConnection.js (alpha.23)
instance.status = request.status;
instance.gamePort = request.gamePort;
await lib.invokeHook(..., "onInstanceStatusChanged", instance, prev);
```

`updateInstanceData` in `controller.js` receives this same mutable reference and then **awaits** a `GetInstanceRequest` before reading `instance.status` and `instance.gamePort`:

```js
// BEFORE this fix — values read AFTER await may be stale
let instanceData = await this.controller.sendTo({ instanceId }, new GetInstanceRequest());
let currentData = {
    status: instance.status,  // ← could have changed during the await!
    game_port: instance.gamePort,  // ← same
    ...
};
```

Because Node.js processes I/O between `await` ticks, a second host status message (e.g. during a rapid restart, crash, or reconnect) can arrive and mutate `instance.status` while `updateInstanceData` is still awaiting the `GetInstanceRequest` response. The post-await reads then capture the **new** status rather than the one that triggered the call, and the wrong status is broadcast to all running instances — making an online instance appear offline.

## Fix

Snapshot all mutable fields from the `instance` object at the **top** of `updateInstanceData`, before any `await`, and use those snapshots throughout:

```js
const status = instance.status;
const gamePort = instance.gamePort;
const name = instance.config.get("instance.name");
const assignedHost = instance.config.get("instance.assigned_host");
// ... use these snapshots instead of reading from instance after await
```

This ensures the stored and broadcast data always reflects the status that originally triggered the call.

## Affected versions

Reproduced against clusterio `2.0.0-alpha.23`. The mutation-in-place behaviour of `InstanceRecord` was introduced in alpha.23 as part of the `InstanceManager` refactor, so earlier versions are not affected.

🤖 Identified and implemented with [Claude Code](https://claude.com/claude-code) — please verify independently.