### PR TITLE
Refactor away GetInstanceRequest

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -2,7 +2,6 @@
 const { BaseControllerPlugin } = require("@clusterio/controller");
 
 const {
-	GetInstanceRequest,
 	GetInstancesRequest,
 	UpdateInstancesEvent,
 } = require("./info");
@@ -30,7 +29,7 @@ class ControllerPlugin extends BaseControllerPlugin {
 			field === "server_select.show_unknown_instances"
 			|| field === "server_select.show_offline_instances"
 		) {
-			await this.updateInstances()
+			this.updateInstances();
 		}
 	}
 
@@ -47,19 +46,15 @@ class ControllerPlugin extends BaseControllerPlugin {
 		return this.controller.config.get("server_select.show_offline_instances");
 	}
 
-	async updateInstanceData(instance) {
+	updateInstanceData(instance) {
 		let instanceId = instance.config.get("instance.id");
 		if (instance.status === "running") {
 			let hostConnection = this.controller.wsServer.hostConnections.get(
 				instance.config.get("instance.assigned_host")
 			);
 			if (!hostConnection) { // Should be impossible
-				return;
+				return undefined;
 			}
-
-			// This request is almost obsolete, it could be removed once
-			// game version becomes known to the controller.
-			let instanceData = await this.controller.sendTo({ instanceId }, new GetInstanceRequest());
 
 			let currentData = {
 				id: instance.id,
@@ -67,7 +62,7 @@ class ControllerPlugin extends BaseControllerPlugin {
 				status: instance.status,
 				game_port: instance.gamePort,
 				public_address: this.controller.hosts.get(instance.config.get("instance.assigned_host"))?.publicAddress,
-				game_version: instanceData.game_version,
+				game_version: instance.factorioVersion,
 			};
 			this.instances.set(instanceId, currentData);
 		}
@@ -84,13 +79,19 @@ class ControllerPlugin extends BaseControllerPlugin {
 		return instanceData;
 	}
 
+	sendInstanceUpdate(instance) {
+			let instanceData = this.updateInstanceData(instance);
+			if (instanceData) {
+				this.controller.sendTo("allInstances",
+					new UpdateInstancesEvent([instanceData], false),
+				);
+			}
+	}
+
 	async onInstanceStatusChanged(instance, prev) {
 		let instanceId = instance.config.get("instance.id");
 		if (this.shouldShowInstance(instance)) {
-			let instanceData = await this.updateInstanceData(instance);
-			this.controller.sendTo("allInstances",
-				new UpdateInstancesEvent([instanceData], false),
-			);
+			this.sendInstanceUpdate(instance);
 
 		} else {
 			this.instances.delete(instanceId);
@@ -106,20 +107,17 @@ class ControllerPlugin extends BaseControllerPlugin {
 	async onInstanceConfigFieldChanged(instance, field, currentValue, previousValue) {
 		if (field === "instance.name") {
 			if (this.shouldShowInstance(instance)) {
-				let instanceData = await this.updateInstanceData(instance);
-				this.controller.sendTo("allInstances",
-					new UpdateInstancesEvent([instanceData], false),
-				);
+				this.sendInstanceUpdate(instance);
 			}
 		}
 	}
 
-	async updateInstances() {
+	updateInstances() {
 		for (let instance of this.controller.instances.values()) {
 			let instanceId = instance.id;
 			if (this.shouldShowInstance(instance)) {
 				if (!this.instances.has(instanceId)) {
-					await this.updateInstanceData(instance);
+					this.updateInstanceData(instance);
 				}
 			} else {
 				this.instances.delete(instanceId);

--- a/info.js
+++ b/info.js
@@ -11,19 +11,6 @@ const instanceProperties = {
 	"public_address": { type: "string" },
 };
 
-class GetInstanceRequest {
-	static type = "request";
-	static src = "controller";
-	static dst = "instance";
-	static plugin = "server_select";
-	static Response = plainJson({
-		type: "object",
-		additionalProperties: false,
-		required: Object.keys(instanceProperties),
-		properties: instanceProperties,
-	});
-}
-
 class GetInstancesRequest {
 	static type = "request";
 	static src = "instance";
@@ -98,7 +85,6 @@ const plugin = {
 	},
 
 	messages: [
-		GetInstanceRequest,
 		GetInstancesRequest,
 		UpdateInstancesEvent,
 	],
@@ -106,7 +92,6 @@ const plugin = {
 
 module.exports = {
 	plugin,
-	GetInstanceRequest,
 	GetInstancesRequest,
 	UpdateInstancesEvent,
 }

--- a/instance.js
+++ b/instance.js
@@ -3,7 +3,6 @@ const lib = require("@clusterio/lib");
 const { BaseInstancePlugin } = require("@clusterio/host");
 
 const {
-	GetInstanceRequest,
 	GetInstancesRequest,
 	UpdateInstancesEvent,
 } = require("./info");
@@ -17,7 +16,6 @@ class InstancePlugin extends BaseInstancePlugin {
 
 		this.pendingCommands = [];
 		this.currentlySending = false;
-		this.instance.handle(GetInstanceRequest, this.handleGetInstanceRequest.bind(this));
 		this.instance.handle(UpdateInstancesEvent, this.handleUpdateInstancesEvent.bind(this));
 	}
 
@@ -43,17 +41,6 @@ class InstancePlugin extends BaseInstancePlugin {
 			this.sendPendingRcon();
 		}
 		return await promise;
-	}
-
-	async handleGetInstanceRequest() {
-		return {
-			id: this.instance.config.get("instance.id"),
-			name: this.instance.name,
-			status: this.instance.status,
-			game_port: this.instance.server.gamePort,
-			game_version: this.instance.server.version,
-			public_address: this.host.config.get("host.public_address"),
-		};
 	}
 
 	async updateList() {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   },
   "homepage": "https://github.com/Hornwitser/server_select#readme",
   "peerDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.16"
+    "@clusterio/lib": "^2.0.0-alpha.19"
   },
   "devDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.16",
-    "@clusterio/web_ui": "^2.0.0-alpha.16",
+    "@clusterio/lib": "^2.0.0-alpha.19",
+    "@clusterio/web_ui": "^2.0.0-alpha.19",
     "eslint": "^8.45.0",
     "webpack": "^5.98.0",
     "webpack-cli": "^5.1.4",


### PR DESCRIPTION
Alpha 19 added the factorioVersion field to the instance details, which is the last bit of data that the GetInstanceRequest used to function. Refactor away this request and turn the relevant logic sync.

### Changelog
```
### Changes
- Removed async logic on the controller side when updating the server list. #8
```